### PR TITLE
Custom resolution with width and height.

### DIFF
--- a/baker.py
+++ b/baker.py
@@ -112,13 +112,15 @@ class PBAKER_OT_bake(bpy.types.Operator):
             color = (0.5, 0.5, 1.0, 1.0)
 
         # resolution
-        res = int(self.settings.custom_resolution) if self.settings.resolution == 'CUSTOM' else int(
+        res_width = int(self.settings.custom_resolution) if self.settings.resolution == 'CUSTOM' else int(
+            self.settings.resolution)
+        res_height = int(self.settings.custom_resolution2) if self.settings.resolution == 'CUSTOM' else int(
             self.settings.resolution)
 
         is_float = False if self.settings.color_depth == '8' else True
 
         image = bpy.data.images.new(
-            name=img_name, width=res, height=res, alpha=alpha, float_buffer=is_float)
+            name=img_name, width=res_width, height=res_height, alpha=alpha, float_buffer=is_float)
 
         if not self.jobname in {'Color', 'Diffuse'}:
             image.colorspace_settings.name = 'Non-Color'

--- a/panel.py
+++ b/panel.py
@@ -249,6 +249,7 @@ class PBAKER_PT_OutputSettings(PBAKER_PT_SubPanel):
         row.prop(self.settings, "resolution", expand=True)
         if self.settings.resolution == 'CUSTOM':
             col.prop(self.settings, "custom_resolution")
+            col.prop(self.settings, "custom_resolution2")
         col.separator()
         col.prop(self.settings, "file_path")
         col.prop(self.settings, "use_overwrite")

--- a/settings.py
+++ b/settings.py
@@ -150,11 +150,19 @@ class PBAKER_settings(PropertyGroup):
     )
 
     custom_resolution: IntProperty(
-        name="Resolution",
-        default=1024,
+        name="Width",
+        default=1920,
         min=1,
         soft_max=8 * 1024
     )
+
+    custom_resolution2: IntProperty(
+        name="Height",
+        default=1080,
+        min=1,
+        soft_max=8 * 1024
+    )
+
     resolution: EnumProperty(
         name="Resolution",
         items=(


### PR DESCRIPTION
I added width and height for custom resolution at output setting. Previously it was only possible to enter one input, thus square outputs.
![image](https://github.com/danielenger/Principled-Baker/assets/26340322/988f2933-9d8b-4eb6-9049-85f1f75b4056)
